### PR TITLE
Add cache clearing after module install/uninstall

### DIFF
--- a/module/scripts/AfterInstall.php
+++ b/module/scripts/AfterInstall.php
@@ -7,6 +7,7 @@ class AfterInstall
     public function run($container)
     {
         $this->container = $container;
+        $this->clearCache();
     }
 
     protected function clearCache()

--- a/module/scripts/AfterUninstall.php
+++ b/module/scripts/AfterUninstall.php
@@ -7,6 +7,7 @@ class AfterUninstall
     public function run($container)
     {
         $this->container = $container;
+        $this->clearCache();
     }
 
     protected function clearCache()

--- a/module/scripts/BeforeInstall.php
+++ b/module/scripts/BeforeInstall.php
@@ -7,6 +7,7 @@ class BeforeInstall
     public function run($container)
     {
         $this->container = $container;
+        $this->clearCache();
     }
 
     protected function clearCache()


### PR DESCRIPTION
## Summary
- ensure installation scripts clear cache by default
- verify PHP syntax on the modified scripts

## Testing
- `php -l module/scripts/AfterInstall.php`
- `php -l module/scripts/AfterUninstall.php`
- `php -l module/scripts/BeforeInstall.php`


------
https://chatgpt.com/codex/tasks/task_e_684b1ee00f548325b57db5676498ef2f