### PR TITLE
Add PHPUnit tests for cache clearing

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,10 @@ This theme replaces the Hub Inspired Theme
 - Use the module\do_not_upload\email_templates\2fa_template.html as 2FA Code template
 - Use the module\do_not_upload\email_templates\password_reset.html as Password Reset template
 - Disable scope colors, tab colors and tab icons
+
+## Testing
+Run all PHPUnit tests with:
+
+```bash
+phpunit tests
+```

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "modern-theme-utt/module",
+    "description": "Modern Theme UTT module",
+    "require": {},
+    "require-dev": {
+        "phpunit/phpunit": "^9"
+    }
+}

--- a/module/scripts/AfterInstall.php
+++ b/module/scripts/AfterInstall.php
@@ -7,6 +7,7 @@ class AfterInstall
     public function run($container)
     {
         $this->container = $container;
+        $this->clearCache();
     }
 
     protected function clearCache()

--- a/module/scripts/AfterUninstall.php
+++ b/module/scripts/AfterUninstall.php
@@ -7,6 +7,7 @@ class AfterUninstall
     public function run($container)
     {
         $this->container = $container;
+        $this->clearCache();
     }
 
     protected function clearCache()

--- a/module/scripts/BeforeInstall.php
+++ b/module/scripts/BeforeInstall.php
@@ -7,6 +7,7 @@ class BeforeInstall
     public function run($container)
     {
         $this->container = $container;
+        $this->clearCache();
     }
 
     protected function clearCache()

--- a/tests/AfterInstallTest.php
+++ b/tests/AfterInstallTest.php
@@ -1,0 +1,27 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../module/scripts/AfterInstall.php';
+
+class AfterInstallTest extends TestCase
+{
+    public function testRunCallsClearCache()
+    {
+        $dataManager = $this->getMockBuilder(stdClass::class)
+            ->addMethods(['clearCache'])
+            ->getMock();
+        $dataManager->expects($this->once())
+            ->method('clearCache');
+
+        $container = $this->getMockBuilder(stdClass::class)
+            ->addMethods(['get'])
+            ->getMock();
+        $container->expects($this->once())
+            ->method('get')
+            ->with('dataManager')
+            ->willReturn($dataManager);
+
+        $script = new AfterInstall();
+        $script->run($container);
+    }
+}

--- a/tests/AfterUninstallTest.php
+++ b/tests/AfterUninstallTest.php
@@ -1,0 +1,27 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../module/scripts/AfterUninstall.php';
+
+class AfterUninstallTest extends TestCase
+{
+    public function testRunCallsClearCache()
+    {
+        $dataManager = $this->getMockBuilder(stdClass::class)
+            ->addMethods(['clearCache'])
+            ->getMock();
+        $dataManager->expects($this->once())
+            ->method('clearCache');
+
+        $container = $this->getMockBuilder(stdClass::class)
+            ->addMethods(['get'])
+            ->getMock();
+        $container->expects($this->once())
+            ->method('get')
+            ->with('dataManager')
+            ->willReturn($dataManager);
+
+        $script = new AfterUninstall();
+        $script->run($container);
+    }
+}

--- a/tests/BeforeInstallTest.php
+++ b/tests/BeforeInstallTest.php
@@ -1,0 +1,27 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../module/scripts/BeforeInstall.php';
+
+class BeforeInstallTest extends TestCase
+{
+    public function testRunCallsClearCache()
+    {
+        $dataManager = $this->getMockBuilder(stdClass::class)
+            ->addMethods(['clearCache'])
+            ->getMock();
+        $dataManager->expects($this->once())
+            ->method('clearCache');
+
+        $container = $this->getMockBuilder(stdClass::class)
+            ->addMethods(['get'])
+            ->getMock();
+        $container->expects($this->once())
+            ->method('get')
+            ->with('dataManager')
+            ->willReturn($dataManager);
+
+        $script = new BeforeInstall();
+        $script->run($container);
+    }
+}


### PR DESCRIPTION
## Summary
- add phpunit as dev dependency
- ensure installer scripts clear cache when run
- add tests verifying clearCache is called
- document test command in README

## Testing
- `phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_684b1ed235508325a2b6ad2ed552f605